### PR TITLE
Adding the possibility of auto naming files based on the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ schema:
 ]
 ```
 
+If you do not provide the title for a URL, the address of the URL will be used as a filename by replacing forbidden characters to underscore (**_**).
+
 #### Installation
 
 ```bash

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -17,6 +17,10 @@ type PrintParams = {
 export class ModuleService {
     private failedInputList: CommandInput = []
 
+    private urlToFilename(url) {
+        return url.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+    }
+
     public async execute(uriList: CommandInput): Promise<void> {
         const browser = await puppeteer.launch({ headless: true });
         // mkdir from timestamp
@@ -59,6 +63,9 @@ export class ModuleService {
 
     private async printUriWebPageToPDF(payload: PrintParams) {
         const { page, uri, dirName, indexOf: index, total } = payload
+        if (uri.title == "") {
+            uri.title = this.urlToFilename(uri.url)
+        }
         console.log(`Printing (${index}/${total}): ${uri.title}`);
         await page.goto(uri.url, { timeout: 0 });
         await page.pdf({ path: `${dirName}/${uri.title}.pdf`, format: 'A4', printBackground: true });


### PR DESCRIPTION
WIth this simple change, it's not necessary to set a name for each url.

The filename will be created using the url, converting forbidden characters to underscore (_) if the field "title" is left blank.

This greatly improves the usage of this tool for large number of URLs and files.